### PR TITLE
PLATOPS-1239: Fix audit exclusions for controllers

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfig.scala
@@ -42,14 +42,22 @@ object ControllerConfigs {
 
     val configMap = (
       for (
-      configs <- configuration.getConfig("controllers").toSeq;
-      key <- configs.subKeys;
-      entryForController <- readCompositeValue(configs, key);
+      config <- configuration.getConfig("controllers").toSeq;
+      controllerName <- controllerNames(config);
+      entryForController <- readCompositeValue(config, controllerName);
       parsedEntryForController = ControllerConfig.fromConfig(entryForController)
-    ) yield (key, parsedEntryForController)
+    ) yield (controllerName, parsedEntryForController)
       ).toMap
 
     ControllerConfigs(configMap)
+  }
+
+  def controllerNames(config: Configuration): List[String] = {
+    def keepOnlyControllerName(s: String): String = {
+      val lastChar = if (s.lastIndexOf(".") != -1) s.lastIndexOf(".") else s.length
+      s.substring(0, lastChar)
+    }
+    config.keys.map(keepOnlyControllerName).toList
   }
 
   private def readCompositeValue(configuration : Configuration, key : String) : Option[Configuration] = {

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/microservice/MicroserviceAuditFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/microservice/MicroserviceAuditFilter.scala
@@ -215,6 +215,6 @@ class DefaultMicroserviceAuditFilter @Inject() (
                                                ) extends MicroserviceAuditFilter with AppName {
 
   override def controllerNeedsAuditing(controllerName: String): Boolean =
-    controllerConfigs.get("controllerName").auditing
+    controllerConfigs.get(controllerName).auditing
 
 }

--- a/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/bootstrap/config/ControllerConfigSpec.scala
@@ -53,15 +53,21 @@ class ControllerConfigSpec extends WordSpec with MustMatchers {
 
     val controllerConfigs = ControllerConfigs.fromConfig(Configuration(
       "controllers.foo.needsAuditing" -> false,
-      "controllers.foo.needsLogging" -> false
+      "controllers.foo.needsLogging" -> false,
+      "controllers.a.b.c.bar.needsAuditing" -> false,
+      "controllers.a.b.c.bar.needsLogging" -> false
     ))
 
     "return loaded configuration" in {
+      val `a.b.c.bar config` = controllerConfigs.get("a.b.c.bar")
 
-      val config = controllerConfigs.get("foo")
+      `a.b.c.bar config`.auditing mustBe false
+      `a.b.c.bar config`.logging mustBe false
 
-      config.auditing mustBe false
-      config.logging mustBe false
+      val fooConfig = controllerConfigs.get("foo")
+
+      fooConfig.auditing mustBe false
+      fooConfig.logging mustBe false
     }
 
     "return default configuration for missing controllers" in {


### PR DESCRIPTION
- Fixes how controllers audig config is read from configuration. Previously only controllers directly in the root package were read
- Fixes a typo for microservice audit filter that also prevented correct checks if audit is needed for controllers