### PR TITLE
[TR] TXM-3316 upgrade play-auditing (for user agent fix)

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     filters,
     "uk.gov.hmrc"                    %% "crypto"                 % "4.4.0",
     "uk.gov.hmrc"                    %% "http-verbs"             % "8.5.0-play-25",
-    "uk.gov.hmrc"                    %% "play-auditing"          % "3.11.0-play-25",
+    "uk.gov.hmrc"                    %% "play-auditing"          % "3.12.0-play-25",
     "uk.gov.hmrc"                    %% "auth-client"            % "2.11.0-play-25",
     "uk.gov.hmrc"                    %% "play-health"            % "3.7.0-play-25",
     "uk.gov.hmrc"                    %% "play-config"            % "7.0.0",


### PR DESCRIPTION
Upgrade play-auditing to include the fix which sets
the user-agent header when writing audits to datastream.