### PR TITLE
Add ServicesConfig binding in bootstrap module

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class SomeConnector @Inject() (client: HttpClient) {
 ## Services config
 
 Bootstrap library comes with default binding for `ServicesConfig`. `ServicesConfig` has been inlined into `bootstrap-play-26` from `play-config`.
-To make further upgrades plainless please use
+To make further upgrades painless please use
 ```scala
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 ```

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ class SomeConnector @Inject() (client: HttpClient) {
 }
 ```
 
+## Services config
+
+Bootstrap library comes with default binding for `ServicesConfig`. `ServicesConfig` has been inlined into `bootstrap-play-26` from `play-config`.
+To make further upgrades plainless please use
+```scala
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+```
+instead
+```scala
+import uk.gov.hmrc.play.config.ServicesConfig
+```
+
 ## User Authorisation
 
 The library supports user authorisation on microservices

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.play.bootstrap
 
+import javax.inject.Singleton
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.bootstrap.config.{ControllerConfigs, ServicesConfigProvider}
@@ -27,7 +28,7 @@ abstract class BootstrapModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[CacheControlConfig].toInstance(CacheControlConfig.fromConfig(configuration)),
     bind[ControllerConfigs].toInstance(ControllerConfigs.fromConfig(configuration)),
-    bind[ServicesConfig].toProvider[ServicesConfigProvider],
+    bind[ServicesConfig].toProvider[ServicesConfigProvider].in[Singleton],
     bind[LoggingFilter].to[DefaultLoggingFilter]
   )
 }

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/BootstrapModule.scala
@@ -18,14 +18,16 @@ package uk.gov.hmrc.play.bootstrap
 
 import play.api.inject.{Binding, Module}
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.play.bootstrap.config.ControllerConfigs
+import uk.gov.hmrc.play.bootstrap.config.{ControllerConfigs, ServicesConfigProvider}
 import uk.gov.hmrc.play.bootstrap.filters.{CacheControlConfig, DefaultLoggingFilter, LoggingFilter}
+import uk.gov.hmrc.play.config.ServicesConfig
 
 abstract class BootstrapModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[CacheControlConfig].toInstance(CacheControlConfig.fromConfig(configuration)),
     bind[ControllerConfigs].toInstance(ControllerConfigs.fromConfig(configuration)),
+    bind[ServicesConfig].toProvider[ServicesConfigProvider],
     bind[LoggingFilter].to[DefaultLoggingFilter]
   )
 }

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/config/DefaultServiceConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/config/DefaultServiceConfig.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.config
+
+import javax.inject.{Inject, Provider}
+import play.api.{Configuration, Environment, Mode}
+import uk.gov.hmrc.play.config.ServicesConfig
+
+class DefaultServicesConfig(val mode: Mode.Mode,
+                            val runModeConfiguration: Configuration) extends ServicesConfig
+
+class ServicesConfigProvider @Inject()(configuration: Configuration, environment: Environment) extends Provider[DefaultServicesConfig] {
+  override def get(): DefaultServicesConfig = new DefaultServicesConfig(environment.mode, configuration)
+}

--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/config/package.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/config/package.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap
+
+package object config {
+  type ServicesConfig = uk.gov.hmrc.play.config.ServicesConfig
+}

--- a/src/test/scala/uk/gov/hmrc/play/bootstrap/ServicesConfigBindingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/bootstrap/ServicesConfigBindingSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.Configuration
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.play.config.ServicesConfig
+
+class ServicesConfigBindingSpec extends WordSpec with MustMatchers {
+
+  def anApplicationWithBoundedServicesConfig(configFile: String): Unit = {
+    lazy val app = new GuiceApplicationBuilder()
+      .configure(Configuration(ConfigFactory.load(configFile)))
+      .build()
+
+    "bind ServicesConfig in default configuration" in {
+      app.injector.instanceOf[ServicesConfig] must not be null
+    }
+
+    "have forward compatible with bootstrap-play-26" in {
+      app.injector.instanceOf[uk.gov.hmrc.play.bootstrap.config.ServicesConfig] must not be null
+    }
+  }
+
+  "A frotnend service" must {
+    behave like anApplicationWithBoundedServicesConfig("frontend.test.conf")
+  }
+
+  "A microservice" must {
+    behave like anApplicationWithBoundedServicesConfig("microservice.test.conf")
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/play/bootstrap/ServicesConfigBindingSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/bootstrap/ServicesConfigBindingSpec.scala
@@ -38,7 +38,7 @@ class ServicesConfigBindingSpec extends WordSpec with MustMatchers {
     }
   }
 
-  "A frotnend service" must {
+  "A frontend service" must {
     behave like anApplicationWithBoundedServicesConfig("frontend.test.conf")
   }
 

--- a/src/test/scala/uk/gov/hmrc/play/bootstrap/config/DefaultServiceConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/bootstrap/config/DefaultServiceConfigSpec.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.bootstrap.config
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.{Configuration, Environment}
+
+class DefaultServiceConfigSpec extends WordSpec with Matchers {
+
+  "DefaultServicesConfig" should {
+    "have provider which works with empty environment" in {
+      new ServicesConfigProvider(Configuration.empty, Environment.simple()).get() should not be null
+    }
+  }
+}


### PR DESCRIPTION
This is backport from `bootstrap-play-26` which increase forward compatibility between `bootstrap-play` libraries.

 