### PR TITLE
TEL-1135 Don't default log requestchain & timestmp

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/bootstrap/filters/LoggingFilter.scala
@@ -65,10 +65,10 @@ trait LoggingFilter extends Filter {
 
     result
       .map { result =>
-        s"${ld.requestChain.value} $start ${rh.method} ${rh.uri} ${result.header.status} ${elapsedTime}ms"
+        s"${rh.method} ${rh.uri} ${result.header.status} ${elapsedTime}ms"
       }
       .recover {
-        case t => s"${ld.requestChain.value} $start ${rh.method} ${rh.uri} $t ${elapsedTime}ms"
+        case t => s"${rh.method} ${rh.uri} $t ${elapsedTime}ms"
       }
   }
 }


### PR DESCRIPTION
This functionality was implemented 6 years ago and there doesn't seem to be anyone around any more that was originally there to explain its purpose. We already have log creation and log ingestion date-time as metadata in Kibana, and are removing this in response to a request from developers of it unnecessarily polluting their logs.